### PR TITLE
Fix: Change ingress annotation

### DIFF
--- a/charts/corteza/templates/corteza/gke/ingress.yaml
+++ b/charts/corteza/templates/corteza/gke/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "corteza.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
   annotations:
-    ingressClassName: "gce"
+    kubernetes.io/ingress.class: "gce"
     {{- if .Values.server.ingress.gcp.managedCertificate.create }}
     networking.gke.io/managed-certificates: {{ include "corteza.server.fullname" . }}
     {{- end }}


### PR DESCRIPTION
This pr changes the old `ingressClassName` annotation to the [google enforced](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#deprecated_annotation) `kubernetes.io/ingress.class`.