### PR TITLE
Bump postgres chart version to 16.x.x

### DIFF
--- a/charts/corteza/Chart.lock
+++ b/charts/corteza/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 14.3.3
-digest: sha256:ad6fd857bd457feb003527254e82a1ceb6c92a66ae6a789440b1779a47fa9a50
-generated: "2024-09-25T15:13:06.308583377+02:00"
+  version: 16.6.2
+digest: sha256:8114e97e434ae5aa1b3680891ec97243fadb4524ac0c47df44e4a472d358c12d
+generated: "2025-04-08T10:43:08.771783188+02:00"

--- a/charts/corteza/Chart.yaml
+++ b/charts/corteza/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 14.x.x
+  version: 16.x.x
 
 maintainers:
 - email: erik.jagyugya@origoss.com


### PR DESCRIPTION
The upgrade is needed as the old version (14.x.x) did not include tolerations config for the backup cronjob, thus we could not schedule them on nodes with taints.