### PR TITLE
Feat/corteza all in one cert manager smoke tests

### DIFF
--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/00-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificaterequests.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+    singular: certificaterequest
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/01-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/01-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+    singular: certificate
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/02-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/02-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.acme.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    - cert-manager-acme
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/03-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/03-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    shortNames:
+    - ciss
+    singular: clusterissuer
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/04-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/04-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    shortNames:
+    - iss
+    singular: issuer
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/05-assert.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/05-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.acme.cert-manager.io
+status:
+  acceptedNames:
+    categories:
+    - cert-manager
+    - cert-manager-acme
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+  conditions:
+  - status: "True"
+    type: NamesAccepted
+  - status: "True"
+    type: Established

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/99-cleanup.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/99-cleanup.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: helm uninstall corteza -n corteza-test

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml
@@ -5,8 +5,3 @@ cert-manager:
   enabled: true
   crds:
     enabled: true
-
-corteza:
-  server:
-    ingress:
-      enabled: false

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml
@@ -1,0 +1,12 @@
+global:
+  domain: &domain "localhost"
+
+cert-manager:
+  enabled: true
+  crds:
+    enabled: true
+
+corteza:
+  server:
+    ingress:
+      enabled: false

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
@@ -2,6 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
   - ./charts/corteza-all-in-one/tests/smoke/with-cert-manager
+namespace: corteza-test
 commands:
   - command: >
       helm upgrade --install corteza ./charts/corteza-all-in-one

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+  - ./charts/corteza-all-in-one/tests/smoke/with-cert-manager
+commands:
+  - command: >
+      helm upgrade --install corteza ./charts/corteza-all-in-one
+      --wait --namespace corteza-test --create-namespace
+      -f charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml

--- a/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
+++ b/charts/corteza-all-in-one/tests/smoke/with-cert-manager/kuttl-test.yaml
@@ -6,5 +6,7 @@ namespace: corteza-test
 commands:
   - command: >
       helm upgrade --install corteza ./charts/corteza-all-in-one
-      --wait --namespace corteza-test --create-namespace
+      --wait
+      --namespace corteza-test
+      --create-namespace
       -f charts/corteza-all-in-one/tests/smoke/with-cert-manager/deployment/values/00-values.yaml


### PR DESCRIPTION
Testing corteza-all-in-one chart with cert-manager enabled - checking successful deployment of CRDs