### PR TITLE
Fix extraenv bug and bump chart version

### DIFF
--- a/charts/corteza/Chart.yaml
+++ b/charts/corteza/Chart.yaml
@@ -3,9 +3,9 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: corteza
-      image: docker.io/cortezaproject/corteza:2024.9.3
+      image: docker.io/cortezaproject/corteza:2024.9.4
     - name: corredor
-      image: docker.io/cortezaproject/corteza-server-corredor:2024.9.3
+      image: docker.io/cortezaproject/corteza-server-corredor:2024.9.4
 
 apiVersion: v2
 name: corteza
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/corteza/templates/corteza/deployment.yaml
+++ b/charts/corteza/templates/corteza/deployment.yaml
@@ -138,8 +138,9 @@ spec:
           {{- end }}
           - name: STORAGE_PATH
             value: "/mnt/corteza/data"
-          {{- with .Values.server.extraEnv }}
-            {{- toYaml . | nindent 10 }}
+          {{- range $key, $value := .Values.server.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
           {{- end }}
           {{- with .Values.server.extraEnvFrom }}
           envFrom:

--- a/charts/corteza/values.yaml
+++ b/charts/corteza/values.yaml
@@ -188,8 +188,7 @@ server:
   ## @param server.extraEnv An array to add extra env vars.
   ##
   extraEnv: []
-    ## - name: "SOME_ENV"
-    ##   value: "some-value"
+    ## "SOME_ENV": "some-value"
   ## @param server.extraEnvFrom An array to pass references of extra env vars.
   ##
   extraEnvFrom: []


### PR DESCRIPTION
Fixing multiple issues with the extraEnvs.
- indent was only 10 instead of 12.
- the result was "key": "value" instead of the proper -name: "xy" value: "yz"

Now we read "key": "value" from tha values.yaml and create the correct format.